### PR TITLE
Fix accessibility, add alt text to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 - html with css style using Mobile First.
 - Responsive desktop version
 - Work and About Sections
-- Contact form
+- Website accessibility
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -130,6 +130,12 @@ Colaborators:
 👤 Eric Boateng
 
 - GitHub: [@Mylo16](https://github.com/Mylo16)
+
+👤 Agyare Kissi Kenneth
+
+- GitHub: [@githubhandle](https://github.com/over-geek)
+- Twitter: [@twitterhandle](https://twitter.com/KissiKenneth)
+- LinkedIn: [LinkedIn](https://www.linkedin.com/in/kenneth-agyare-kissi-673a01186/)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <body>
     <header class="toolbar">
         <div>
-            <a href="#"><img class="logo" src="images/monologo.png"></a>
+            <a href="#"><img class="logo" src="images/monologo.png" alt="logo"></a>
         </div>
         <nav class="navigation">
             <a href="#work">Portfolio</a>
@@ -21,7 +21,7 @@
             <a href="#contact">Contact</a>
         </nav>
         <nav class="menu">
-            <a href="#"><img src="images/Union.png"></a>
+            <a href="#"><img src="images/Union.png" alt="Menu"></a>
         </nav>
     </header>
     <section class="headline" id="head">
@@ -32,9 +32,9 @@
         <h4 class="connect">LET'S CONNECT</h4>
         <div>
             <ul class="personalMedia">
-                <li><a class="media" href="https://twitter.com/Santiag24209785"><img src="images/twitter.png"></a></li>
-                <li><a class="media" href="https://www.linkedin.com/in/santiago-munoz-0b2b1a260/"><img src="images/linkedin.png"></a></li>
-                <li><a class="media" href="https://github.com/smunoz1988"><img src="images/github.png"></a></li>
+                <li><a class="media" href="https://twitter.com/Santiag24209785"><img src="images/twitter.png" alt="twitter"></a></li>
+                <li><a class="media" href="https://www.linkedin.com/in/santiago-munoz-0b2b1a260/"><img src="images/linkedin.png" alt="linkedin"></a></li>
+                <li><a class="media" href="https://github.com/smunoz1988"><img src="images/github.png" alt="Github"></a></li>
             </ul>
         </div>
     </section>
@@ -127,9 +127,9 @@
             <h4 class="connect">LET'S CONNECT</h4>
             <div class="social">
                 <ul class="personalMedia">
-                    <li><a class="media" href="https://twitter.com/Santiag24209785"><img src="images/twitter.png"></a></li>
-                    <li><a class="media" href="https://www.linkedin.com/in/santiago-munoz-0b2b1a260/"><img src="images/linkedin.png"></a></li>
-                    <li><a class="media" href="https://github.com/smunoz1988"><img src="images/github.png"></a></li>
+                    <li><a class="media" href="https://twitter.com/Santiag24209785"><img src="images/twitter.png" alt="twitter"></a></li>
+                    <li><a class="media" href="https://www.linkedin.com/in/santiago-munoz-0b2b1a260/"><img src="images/linkedin.png" alt="linkedin"></a></li>
+                    <li><a class="media" href="https://github.com/smunoz1988"><img src="images/github.png" alt="Github"></a></li>
                 </ul>
             </div>
             <button class="resumeButton" type="button">Get my resume</button>
@@ -141,9 +141,9 @@
                     <img class="arrow" src="images/arrowD.png">
                 </div>
                 <ul class="languaje">
-                    <li class="js"><img class="lang" src="images/js.png"><p>JavaScript</p></li>
-                    <li class="html"><img class="lang" src="images/html.png"><p>HTML</p></li>
-                    <li class="css"><img class="lang" src="images/css.png"><p>CSS</p></li>
+                    <li class="js"><img class="lang" src="images/js.png" alt="JavaScript"><p>JavaScript</p></li>
+                    <li class="html"><img class="lang" src="images/html.png" alt="html"><p>HTML</p></li>
+                    <li class="css"><img class="lang" src="images/css.png" alt="CSS"><p>CSS</p></li>
                 </ul>
                 <div class="container">
                     <p class="atribute">Frameworks</p>


### PR DESCRIPTION
## Portfolio Project - Accessibility changes:

Collaborators:  

- Kenneth Agyare 
- Santiago Muñoz

In this milestone, we checked:

- Page titles: no issues found.
- Image text alternatives:

> 1. Logo image without alt. https://github.com/smunoz1988/Portfolio-mobile-first/compare/master...Accessibility#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R16

> 2. Nav menu without alt. https://github.com/smunoz1988/Portfolio-mobile-first/compare/master...Accessibility#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R24

> 3. Languages logos without alt. https://github.com/smunoz1988/Portfolio-mobile-first/compare/master...Accessibility#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L144-L146

- Text headings: no issues found.
- Color contrast: no issues found.
- Resize: no issues found.
- Interaction: no issues found.
- Moving content: no issues found.
- Multimedia: no issues found.

- The basic structure of the page: 

>1. Social media icons without alt. https://github.com/smunoz1988/Portfolio-mobile-first/compare/master...Accessibility#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R35-R37

Another changes:

- Update README: collaborators and features (accessibility). 